### PR TITLE
feat(admin): restringir registro jugadores y crear campo MatchPlayed

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -266,6 +266,7 @@ model User {
   tournamentsPlayed Int          @default(0)
   victoryPoints     Int          @default(0)
   eloPoints         Int          @default(0)
+  matchesPlayed     Int          @default(0)
   password          String?
   emailVerified     DateTime?
   image             String       @default("player")

--- a/src/actions/tournaments/add-player.action.ts
+++ b/src/actions/tournaments/add-player.action.ts
@@ -2,10 +2,24 @@
 
 import { prisma } from "@/lib/prisma";
 import { TournamentPlayerSchema, TournamentPlayerInput } from "@/schemas";
+import { Role } from "@prisma/client";
 
 export async function addPlayerAction(input: TournamentPlayerInput) {
   try {
     const data = TournamentPlayerSchema.parse(input);
+
+    const user = await prisma.user.findUnique({
+      where: { id: data.userId },
+      select: { role: true },
+    });
+
+    if (!user) {
+      throw new Error("El jugador no existe");
+    }
+
+    if (user.role !== Role.player) {
+      throw new Error("Solo usuarios con rol player pueden registrarse");
+    }
 
     const exists = await prisma.tournamentPlayer.findFirst({
       where: {

--- a/src/actions/tournaments/finalize-tournament.action.ts
+++ b/src/actions/tournaments/finalize-tournament.action.ts
@@ -5,7 +5,7 @@ import { FinalizeTournamentSchema } from "@/schemas";
 
 export async function finalizeTournamentAction(input: {
   tournamentId: string;
-  players: { userId: string; wins: number }[];
+  players: { userId: string; wins: number; matches: number }[];
 }) {
   try {
     const data = FinalizeTournamentSchema.parse(input);
@@ -23,6 +23,7 @@ export async function finalizeTournamentAction(input: {
           data: {
             victoryPoints: { increment: player.wins },
             eloPoints: { increment: player.wins },
+            matchesPlayed: { increment: player.matches },
             tournamentsPlayed: { increment: 1 },
           },
         })

--- a/src/actions/tournaments/search-users.action.ts
+++ b/src/actions/tournaments/search-users.action.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { Role } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { SearchUsersSchema, SearchUsersInput } from "@/schemas";
 
@@ -30,6 +31,7 @@ export async function searchUsersAction(input: SearchUsersInput) {
             },
           },
         ],
+        role: Role.player,
       },
       select: {
         id: true,

--- a/src/components/perfil/perfil.tsx
+++ b/src/components/perfil/perfil.tsx
@@ -133,14 +133,17 @@ export const Pefil = ({
     setSelectedAvatar(baseAvatar);
   };
 
+  const isPlayer = user.role === "player";
   const hasBaseTournament =
     Boolean(activeTournamentState?.currentTournament) ||
     Boolean(activeTournamentState?.lastTournament);
   const hasSelectedTournament = Boolean(selectedTournament);
 
-  const tabs: TabKey[] = hasBaseTournament
-    ? ["current", "history"]
-    : ["history"];
+  const tabs: TabKey[] = isPlayer
+    ? hasBaseTournament
+      ? ["current", "history"]
+      : ["history"]
+    : [];
 
   if (hasSelectedTournament) {
     tabs.push("selected");
@@ -328,31 +331,33 @@ export const Pefil = ({
         )}
 
         {/* Tabs */}
-        <div className="flex mt-10 border-b border-slate-200 dark:border-tournament-dark-border w-full justify-center md:justify-start">
-          {tabs.map((tab) => (
-            <button
-              key={tab}
-              onClick={() => handleTabChange(tab)}
-              className={`px-6 py-2 text-sm font-semibold transition ${
-                activeTab === tab
-                  ? "text-purple-600 border-b-2 border-purple-600"
-                  : "text-slate-500 dark:text-slate-400 hover:text-purple-600 dark:hover:text-purple-300"
-              }`}
-            >
-              {tab === "current"
-                ? currentTabLabel
-                : tab === "history"
-                ? "Historial de torneos"
-                : tab === "selected"
-                ? "Torneo"
-                : "Mis mazos"}
-            </button>
-          ))}
-        </div>
+        {isPlayer && (
+          <div className="flex mt-10 border-b border-slate-200 dark:border-tournament-dark-border w-full justify-center md:justify-start">
+            {tabs.map((tab) => (
+              <button
+                key={tab}
+                onClick={() => handleTabChange(tab)}
+                className={`px-6 py-2 text-sm font-semibold transition ${
+                  activeTab === tab
+                    ? "text-purple-600 border-b-2 border-purple-600"
+                    : "text-slate-500 dark:text-slate-400 hover:text-purple-600 dark:hover:text-purple-300"
+                }`}
+              >
+                {tab === "current"
+                  ? currentTabLabel
+                  : tab === "history"
+                  ? "Historial de torneos"
+                  : tab === "selected"
+                  ? "Torneo"
+                  : "Mis mazos"}
+              </button>
+            ))}
+          </div>
+        )}
 
         {/* Contenido */}
         <div className="mt-8 w-full">
-          {activeTab === "current" && activeTournamentState && (
+          {isPlayer && activeTab === "current" && activeTournamentState && (
             <ProfileCurrentTournament
               data={activeTournamentState}
               hasShownInProgressWarning={hasShownInProgressWarning}
@@ -363,7 +368,8 @@ export const Pefil = ({
             />
           )}
 
-          {activeTab === "selected" &&
+          {isPlayer &&
+            activeTab === "selected" &&
             activeTournamentState &&
             selectedTournament && (
               <ProfileCurrentTournament
@@ -377,7 +383,7 @@ export const Pefil = ({
               />
             )}
 
-          {activeTab === "history" && (
+          {isPlayer && activeTab === "history" && (
             <ProfileTournamentHistory
               tournaments={tournaments}
               onSelectTournament={handleHistorySelect}

--- a/src/schemas/tournament/tournament.schema.ts
+++ b/src/schemas/tournament/tournament.schema.ts
@@ -54,6 +54,7 @@ export const FinalizeTournamentSchema = z.object({
     z.object({
       userId: z.string().min(1),
       wins: z.number().int().min(0),
+      matches: z.number().int().min(0),
     })
   ),
 });

--- a/src/store/tournament/tournament.store.ts
+++ b/src/store/tournament/tournament.store.ts
@@ -355,9 +355,24 @@ export const useTournamentStore = create<TournamentStoreState>((set, get) => ({
       // Inicializa los contadores en 0 para todos los inscritos.
       const winsByUserId = new Map(state.players.map((p) => [p.userId, 0]));
 
+      // Contador de matches jugados por usuario.
+      const matchesByUserId = new Map(state.players.map((p) => [p.userId, 0]));
+
       // Suma 1 victoria por match ganado (P1/P2); empates no cuentan.
       state.rounds.forEach((round) => {
         round.matches.forEach((match) => {
+          // Cuenta el match jugado para ambos jugadores.
+          const incrementUserMatch = (playerId: string | null | undefined) => {
+            if (!playerId) return;
+            const userId = playerIdToUserId.get(playerId);
+            if (!userId) return;
+
+            matchesByUserId.set(userId, (matchesByUserId.get(userId) ?? 0) + 1);
+          };
+
+          incrementUserMatch(match.player1Id);
+          incrementUserMatch(match.player2Id);
+
           if (match.result === "P1") {
             const userId = playerIdToUserId.get(match.player1Id);
             if (userId) {
@@ -378,6 +393,7 @@ export const useTournamentStore = create<TournamentStoreState>((set, get) => ({
       const players = state.players.map((p) => ({
         userId: p.userId,
         wins: winsByUserId.get(p.userId) ?? 0,
+        matches: matchesByUserId.get(p.userId) ?? 0,
       }));
 
       // Actualiza el torneo y los usuarios en el backend.


### PR DESCRIPTION
- searchUsersAction ahora filtra solamente usuarios con rol player, de modo que el selector de /admin/torneos/[id] no muestra otros roles y no permite registrarlos.
- addPlayerAction valida que el jugador que se intenta registrar tenga el rol player, dando error controlado si no es así.
- Perfil solo renderiza los tabs y vistas de torneos cuando el usuario actual es un player, ocultando esa sección para otros roles y manteniendo la interfaz centrada en el perfil/avatares.
- añadir matchesPlayed al modelo de user y actualizar las acciones del torneo para realizar un seguimiento de los partidos.